### PR TITLE
Fix: CSS 밀림 이슈 #32 해결

### DIFF
--- a/community/css/header.css
+++ b/community/css/header.css
@@ -30,6 +30,14 @@ body{
 .header h1{
     margin: 0;
 }
+.profile{
+    position: absolute;
+    width: 46px;
+    height: 36px;
+    left: -14px;
+    display: flex;
+    justify-content: flex-end;
+}
 .profile-icon{
     width: 36px;
     height: 36px;

--- a/community/html/editBoard.html
+++ b/community/html/editBoard.html
@@ -19,7 +19,9 @@
             <a id="back-page" href="/main"> < </a>
         </div>
         <a href="/main" style="font-size: 32px; font-weight: 400; text-decoration: none; color: black;">£ 야옹이 광장 ¢</a><div class="dropdown">
-            <img src="./img/profile.jpeg" class="profile-icon" alt="Icon">
+            <div class="profile">
+                <img src="../img/profile.jpeg" class="profile-icon" alt="Icon">
+            </div>
             <div class="dropdown-menu">
                 <div class="dropdown-element" onclick="location.href='/users/info-edit';">회원정보수정</div>
                 <div class="dropdown-element" onclick="location.href='/users/pwd-edit';">비밀번호수정</div>

--- a/community/html/editPassword.html
+++ b/community/html/editPassword.html
@@ -17,7 +17,9 @@
     <div class="header" >
         <a href="/main" style="font-size: 32px; font-weight: 400; text-decoration: none; color: black;">£ 야옹이 광장 ¢</a> 
         <div class="dropdown">
-            <img src="" class="profile-icon" alt="Icon">
+            <div class="profile">
+                <img src="../img/profile.jpeg" class="profile-icon" alt="Icon">
+            </div>
             <div class="dropdown-menu">
                 <div class="dropdown-element" onclick="location.href='/users/info-edit';">회원정보수정</div>
                 <div class="dropdown-element" onclick="location.href='/users/pwd-edit';">비밀번호수정</div>

--- a/community/html/editUserInfo.html
+++ b/community/html/editUserInfo.html
@@ -17,7 +17,9 @@
     <div class="header" >
         <a href="/main" style="font-size: 32px; font-weight: 400; text-decoration: none; color: black;">£ 야옹이 광장 ¢</a> 
         <div class="dropdown">
-            <img src="" class="profile-icon" alt="Icon">
+            <div class="profile">
+                <img src="../img/profile.jpeg" class="profile-icon" alt="Icon">
+            </div>
             <div class="dropdown-menu">
                 <div class="dropdown-element" onclick="location.href='/users/info-edit';">회원정보수정</div>
                 <div class="dropdown-element" onclick="location.href='/users/pwd-edit';">비밀번호수정</div>

--- a/community/html/main.html
+++ b/community/html/main.html
@@ -15,7 +15,9 @@
     <div class="header" >
         <a href="/main" style="font-size: 32px; font-weight: 400; text-decoration: none; color: black;">£ 야옹이 광장 ¢</a> 
         <div class="dropdown">
-            <img src="./img/profile.jpeg" class="profile-icon" alt="Icon">
+            <div class="profile">
+                <img src="../img/profile.jpeg" class="profile-icon" alt="Icon">
+            </div>
             <div class="dropdown-menu">
                 <div class="dropdown-element" onclick="location.href='/users/info-edit';">회원정보수정</div>
                 <div class="dropdown-element" onclick="location.href='/users/pwd-edit';">비밀번호수정</div>

--- a/community/html/viewBoard.html
+++ b/community/html/viewBoard.html
@@ -20,7 +20,9 @@
         </div>
         <a href="/main" style="font-size: 32px; font-weight: 400; text-decoration: none; color: black;">£ 야옹이 광장 ¢</a>
         <div class="dropdown">
-            <img src="" class="profile-icon" alt="Icon">
+            <div class="profile">
+                <img src="../img/profile.jpeg" class="profile-icon" alt="Icon">
+            </div>
             <div class="dropdown-menu">
                 <div class="dropdown-element" onclick="location.href='/users/info-edit';">회원정보수정</div>
                 <div class="dropdown-element" onclick="location.href='/users/pwd-edit';">비밀번호수정</div>

--- a/community/html/writeBoard.html
+++ b/community/html/writeBoard.html
@@ -20,11 +20,13 @@
         </div>
         <a href="/main" style="font-size: 32px; font-weight: 400; text-decoration: none; color: black;">£ 야옹이 광장 ¢</a>
         <div class="dropdown">
-            <img src="../img/profile.jpeg" class="profile-icon" alt="Icon">
+            <div class="profile">
+                <img src="../img/profile.jpeg" class="profile-icon" alt="Icon">
+            </div>
             <div class="dropdown-menu">
-                <div class="dropdown-element"><a href="/users/info-edit">회원정보수정</a></div>
-                <div class="dropdown-element"><a href="/users/pwd-edit">비밀번호수정</a></div>
-                <div id="logout-btn" class="dropdown-element"><a>로그아웃</a></div>
+                <div class="dropdown-element" onclick="location.href='/users/info-edit';">회원정보수정</div>
+                <div class="dropdown-element" onclick="location.href='/users/pwd-edit';">비밀번호수정</div>
+                <div id="logout-btn" class="dropdown-element">로그아웃</div>
             </div>
         </div>
     </div>

--- a/community/js/dropdownMenu.js
+++ b/community/js/dropdownMenu.js
@@ -1,4 +1,4 @@
-const profileIcon = document.querySelector('.profile-icon');
+const profileIcon = document.querySelector('.profile');
 const dropdownMenu = document.querySelector('.dropdown-menu');
 const dropdownElement = document.querySelector('.dropdown-element');
 profileIcon.addEventListener('mouseenter', () => {


### PR DESCRIPTION
추가로 프로필 아이콘에 마우스 호버시 드롭다운이 보이는 과정에서 호버가 되는 범위가 너무 좁아 드롭다운메뉴가 잘 사라지는 불편함이 발생하였음 때문에 호버의 범위를 프로필 아이콘 보다 살짝 더 넓게 조정하였음